### PR TITLE
docs: fix manual installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,14 @@ cp .env.example .env
 
 # Start with Docker Compose
 docker-compose up -d
+```
 
-# Access at http://localhost:3000
-Manual Installation
-bash# Clone the repository
+Access at http://localhost:3000
+
+### Manual Installation
+
+```bash
+# Clone the repository
 git clone https://github.com/JustTechCom/JustDesk.git
 cd JustDesk
 
@@ -47,6 +51,8 @@ cp packages/frontend/.env.local.example packages/frontend/.env.local
 npm run dev
 
 # Access at http://localhost:3000
+```
+
 🛠️ Technology Stack
 
 Frontend: Next.js, React, Tailwind CSS


### PR DESCRIPTION
## Summary
- close Docker code block and show access instructions
- add "Manual Installation" heading and fix repository clone instruction

## Testing
- `npm test` (fails: jest not configured for packages)
- `npm run lint` (fails: ESLint parsing error in frontend)


------
https://chatgpt.com/codex/tasks/task_e_688c91187d10832da3494cb67de792b7