### PR TITLE
Remove waiting and live session screens

### DIFF
--- a/packages/frontend/src/components/ShareScreenComponent.js
+++ b/packages/frontend/src/components/ShareScreenComponent.js
@@ -1,8 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
 import Head from 'next/head';
-import { Monitor, Copy, CheckCircle, XCircle, Users, Wifi, AlertCircle, Play, Square } from 'lucide-react';
-import Layout from './Layout';
+import { AlertCircle } from 'lucide-react';
 import ScreenShare from './ScreenShare';
 import ConnectionPanel from './ConnectionPanel';
 import useWebRTC from '../hooks/useWebRTC';
@@ -207,17 +206,6 @@ export default function ShareScreenComponent() {
     }
   };
 
-  // Calculate session time for display
-  const getSessionInfo = () => {
-    if (isSharing && sharingStartTime) {
-      const elapsed = Date.now() - sharingStartTime;
-      const minutes = Math.floor(elapsed / (1000 * 60));
-      const seconds = Math.floor((elapsed % (1000 * 60)) / 1000);
-      return `${minutes}:${seconds.toString().padStart(2, '0')}`;
-    }
-    return null;
-  }; 
-
   // Debug: viewer sayısının değişimini izle
   useEffect(() => {
     console.log('Viewers updated:', viewers);
@@ -247,23 +235,6 @@ export default function ShareScreenComponent() {
                 </div>
               )}
                
-              {/* Session Status */}
-              {roomId && (
-                <div className="mt-4 inline-flex items-center space-x-4 text-sm">
-                  <div className="flex items-center">
-                    <div className={`w-3 h-3 rounded-full mr-2 ${isSharing ? 'bg-green-400' : 'bg-yellow-400'}`}></div>
-                    <span className="text-gray-300">
-                      {isSharing ? 'Live Session' : 'Ready to Share'}
-                    </span>
-                  </div>
-                  {isSharing && sharingStartTime && (
-                    <span className="text-blue-400">
-                      Duration: {getSessionInfo()}
-                    </span>
-                  )}
-                </div>
-              )}
-              
               {/* Debug panel - sadece development için */}
               {process.env.NODE_ENV === 'development' && (
                 <div className="mt-4 bg-gray-800/50 rounded-lg p-3 text-sm text-gray-300">
@@ -308,52 +279,6 @@ export default function ShareScreenComponent() {
               </div>
             </div>
 
-            {/* Live Session Bar - Sharing başladığında görünür */}
-            {isSharing && (
-              <div className="mt-8 bg-white/10 backdrop-blur-lg rounded-xl p-4 border border-white/20">
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center space-x-4">
-                    <div className="flex items-center">
-                      <div className="w-3 h-3 bg-red-500 rounded-full animate-pulse mr-2"></div>
-                      <span className="text-white font-medium">LIVE</span>
-                    </div>
-                    <div className="flex items-center">
-                      <Users className="w-5 h-5 text-blue-400 mr-2" />
-                      <span className="text-white">{viewers.length} viewers watching</span>
-                    </div>
-                    <div className="flex items-center">
-                      <Clock className="w-5 h-5 text-green-400 mr-2" />
-                      <span className="text-white">Duration: {getSessionInfo() || '0:00'}</span>
-                    </div>
-                  </div>
-                  <div className="text-gray-400 text-sm"> 
-                    Started at {sharingStartTime ? new Date(sharingStartTime).toLocaleTimeString() : '--:--'}
-                  </div>
-                </div>
-              </div>
-            )}
-
-            {/* Room Ready State - Room var ama sharing başlamamış */}
-            {roomId && !isSharing && (
-              <div className="mt-8 bg-yellow-600/20 backdrop-blur-lg rounded-xl p-4 border border-yellow-400/30">
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center space-x-4">
-                    <div className="flex items-center">
-                      <div className="w-3 h-3 bg-yellow-400 rounded-full mr-2"></div>
-                      <span className="text-white font-medium">Room Ready</span>
-                    </div>
-                    <div className="flex items-center">
-                      <Users className="w-5 h-5 text-blue-400 mr-2" />
-                      <span className="text-white">{viewers.length} waiting</span>
-                    </div>
-                  </div>
-                  <div className="text-yellow-200 text-sm flex items-center">
-                    <Play className="w-4 h-4 mr-1" />
-                    Click "Start Sharing" to begin 
-                  </div>
-                </div>
-              </div>
-            )}
           </div>
         </div>
       </div>

--- a/packages/frontend/src/pages/share.js
+++ b/packages/frontend/src/pages/share.js
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
 import Head from 'next/head'; 
-import { Wifi, Users, AlertCircle, Monitor, Clock, Play } from 'lucide-react'; 
+import { AlertCircle } from 'lucide-react';
 import Layout from '../components/Layout';
 import ScreenShare from '../components/ScreenShare';
 import ConnectionPanel from '../components/ConnectionPanel';
@@ -219,31 +219,10 @@ export default function ShareScreen() {
     }
   };
 
-  // Calculate current session time
-  const getCurrentSessionTime = () => {
-    if (isSharing && sharingStartTime) {
-      const elapsed = Date.now() - sharingStartTime;
-      const minutes = Math.floor(elapsed / (1000 * 60));
-      const seconds = Math.floor((elapsed % (1000 * 60)) / 1000);
-      return `${minutes}:${seconds.toString().padStart(2, '0')}`;
-    }
-    return null;
-  };
- 
-
   // Debug: viewer sayısının değişimini izle
   useEffect(() => {
     console.log('👥 Viewers state updated:', viewers.length, viewers);
   }, [viewers]);
-
-  // Debugging function - development only
-  const debugRoomStatus = async () => {
-    if (socket && roomId) {
-      socket.emit('get-room-status', roomId, (response) => {
-        console.log('🐛 Room status debug:', response);
-      });
-    }
-  };
 
   return (
     <Layout>
@@ -269,28 +248,6 @@ export default function ShareScreen() {
                 </div>
               )}
                
-              {/* Session Status Indicator */}
-              {roomId && (
-                <div className="mt-4 inline-flex items-center space-x-4 text-sm">
-                  <div className="flex items-center">
-                    <div className={`w-3 h-3 rounded-full mr-2 ${
-                      isSharing ? 'bg-green-400 animate-pulse' : 'bg-yellow-400'
-                    }`}></div>
-                    <span className="text-gray-300">
-                      {isSharing ? 'Live Session' : 'Ready to Share'}
-                    </span>
-                  </div>
-                  {isSharing && sharingStartTime && (
-                    <div className="flex items-center">
-                      <Clock className="w-4 h-4 text-blue-400 mr-1" />
-                      <span className="text-blue-400">
-                        {getCurrentSessionTime()}
-                      </span>
-                    </div>
-                  )}
-                </div>
-              )}
-              
               {/* Debug panel - sadece development için */}
               {process.env.NODE_ENV === 'development' && (
                 <div className="mt-4 bg-gray-800/50 rounded-lg p-3 text-sm text-gray-300">
@@ -350,54 +307,6 @@ export default function ShareScreen() {
               </div>
             </div>
 
-            {/* Live Session Info */}
-            {isSharing && (
-              <div className="mt-8 bg-white/10 backdrop-blur-lg rounded-xl p-4 border border-white/20">
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center space-x-4">
-                    <div className="flex items-center">
-                      <div className="w-3 h-3 bg-red-500 rounded-full animate-pulse mr-2"></div>
-                      <span className="text-white font-medium">LIVE</span>
-                    </div>
-                    <div className="flex items-center">
-                      <Users className="w-5 h-5 text-blue-400 mr-2" />
-                      <span className="text-white">{viewers.length} viewers watching</span>
-                    </div>
-                    <div className="flex items-center">
-                      <Clock className="w-5 h-5 text-green-400 mr-2" />
-                      <span className="text-white">
-                        Duration: {getCurrentSessionTime() || '0:00'}
-                      </span>
-                    </div>
-                  </div>
-                  <div className="text-gray-400 text-sm"> 
-                    Started at {sharingStartTime ? new Date(sharingStartTime).toLocaleTimeString() : '--:--'}
-                  </div>
-                </div>
-              </div>
-            )}
-
-            {/* Waiting State */}
-            {roomId && !isSharing && (
-              <div className="mt-8 bg-yellow-600/20 backdrop-blur-lg rounded-xl p-4 border border-yellow-400/30">
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center space-x-4">
-                    <div className="flex items-center">
-                      <div className="w-3 h-3 bg-yellow-400 rounded-full mr-2"></div>
-                      <span className="text-white font-medium">Room Ready</span>
-                    </div>
-                    <div className="flex items-center">
-                      <Users className="w-5 h-5 text-blue-400 mr-2" />
-                      <span className="text-white">{viewers.length} waiting</span>
-                    </div>
-                  </div>
-                  <div className="text-yellow-200 text-sm flex items-center">
-                    <Play className="w-4 h-4 mr-1" />
-                    Timer starts when you begin sharing 
-                  </div>
-                </div>
-              </div>
-            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- strip ShareScreenComponent of session status, live session bar, and waiting panel
- remove corresponding panels from share page

## Testing
- `npx lerna run test -- --passWithNoTests`
- `npm run lint` *(fails: parsing errors and prettier issues)*

------
https://chatgpt.com/codex/tasks/task_e_688c96c6555c832db78b00649961c906