### PR TITLE
feat: validate environment variables

### DIFF
--- a/packages/backend/src/config/index.js
+++ b/packages/backend/src/config/index.js
@@ -1,32 +1,58 @@
 require('dotenv').config();
+const Joi = require('joi');
+
+// Validate and parse environment variables
+const envSchema = Joi.object({
+  NODE_ENV: Joi.string().default('development'),
+  PORT: Joi.string().pattern(/^\d+$/).default('3001'),
+  FRONTEND_URL: Joi.string().uri().required(),
+  REDIS_URL: Joi.string().uri(),
+  REDIS_HOST: Joi.string().default('localhost'),
+  REDIS_PORT: Joi.string().pattern(/^\d+$/).default('6379'),
+  REDIS_PASSWORD: Joi.string().allow(''),
+  SESSION_SECRET: Joi.string().default('change-this-secret'),
+  JWT_SECRET: Joi.string().default('change-this-jwt-secret'),
+  RATE_LIMIT_WINDOW_MS: Joi.string().pattern(/^\d+$/).default(String(15 * 60 * 1000)),
+  RATE_LIMIT_MAX_REQUESTS: Joi.string().pattern(/^\d+$/).default('100'),
+  LOG_LEVEL: Joi.string().default('info'),
+  LOG_FILE: Joi.string().default('logs/app.log')
+}).unknown();
+
+const { value: env, error } = envSchema.validate(process.env, { abortEarly: false });
+
+if (error) {
+  console.error('❌ Environment validation error:', error.details.map(d => d.message).join(', '));
+  process.exit(1);
+}
 
 module.exports = {
   app: {
-    env: process.env.NODE_ENV || 'development',
-    port: parseInt(process.env.PORT, 10) || 3001,
-    frontendUrl: process.env.FRONTEND_URL || 'http://localhost:3000'
+    env: env.NODE_ENV,
+    port: parseInt(env.PORT, 10),
+    frontendUrl: env.FRONTEND_URL
   },
   redis: {
-    host: process.env.REDIS_HOST || 'localhost',
-    port: parseInt(process.env.REDIS_PORT, 10) || 6379,
-    password: process.env.REDIS_PASSWORD,
+    url: env.REDIS_URL,
+    host: env.REDIS_HOST,
+    port: parseInt(env.REDIS_PORT, 10),
+    password: env.REDIS_PASSWORD,
     db: 0,
     keyPrefix: 'justdesk:'
   },
   security: {
-    sessionSecret: process.env.SESSION_SECRET || 'change-this-secret',
-    jwtSecret: process.env.JWT_SECRET || 'change-this-jwt-secret',
+    sessionSecret: env.SESSION_SECRET,
+    jwtSecret: env.JWT_SECRET,
     bcryptRounds: 10
   },
   rateLimit: {
-    windowMs: parseInt(process.env.RATE_LIMIT_WINDOW_MS, 10) || 15 * 60 * 1000,
-    max: parseInt(process.env.RATE_LIMIT_MAX_REQUESTS, 10) || 100
+    windowMs: parseInt(env.RATE_LIMIT_WINDOW_MS, 10),
+    max: parseInt(env.RATE_LIMIT_MAX_REQUESTS, 10)
   },
   cors: {
-    origin: process.env.FRONTEND_URL || 'http://localhost:3000',
+    origin: env.FRONTEND_URL,
     credentials: true,
     methods: ['GET', 'POST'],
-    allowedHeaders: ['Content-Type', 'Authorization']
+    allowedHeaders: ['Content-Type', 'Authorization'],
   },
   room: {
     maxViewers: 10,
@@ -41,7 +67,8 @@ module.exports = {
     ]
   },
   logging: {
-    level: process.env.LOG_LEVEL || 'info',
-    file: process.env.LOG_FILE || 'logs/app.log'
+    level: env.LOG_LEVEL,
+    file: env.LOG_FILE
   }
 };
+

--- a/packages/backend/src/server.js
+++ b/packages/backend/src/server.js
@@ -6,6 +6,7 @@ const cors = require('cors');
 const rateLimit = require('express-rate-limit');
 const helmet = require('helmet');
 const compression = require('compression');
+const config = require('./config');
 
 const app = express();
 const httpServer = createServer(app);
@@ -89,8 +90,8 @@ let redisHealthCache = {
 };
 
 try {
-  if (process.env.REDIS_URL) {
-    redis = new Redis(process.env.REDIS_URL, {
+  if (config.redis.url) {
+    redis = new Redis(config.redis.url, {
       retryStrategy: (times) => {
         console.log(`Redis retry attempt ${times}`);
         return Math.min(times * 50, 2000);
@@ -102,9 +103,9 @@ try {
     });
   } else {
     redis = new Redis({
-      host: process.env.REDIS_HOST || 'localhost',
-      port: process.env.REDIS_PORT || 6379,
-      password: process.env.REDIS_PASSWORD,
+      host: config.redis.host,
+      port: config.redis.port,
+      password: config.redis.password,
       retryStrategy: (times) => {
         console.log(`Redis retry attempt ${times}`);
         return Math.min(times * 50, 2000);
@@ -142,7 +143,7 @@ try {
 // CORS configuration
 const corsOptions = {
   origin: [
-    process.env.FRONTEND_URL,
+    config.app.frontendUrl,
     'http://localhost:3000',
     'https://localhost:3000',
     /\.onrender\.com$/,
@@ -819,10 +820,10 @@ setInterval(async () => {
  
 
 // Start server
-const PORT = process.env.PORT || 3001;
+const PORT = config.app.port;
 httpServer.listen(PORT, '0.0.0.0', () => {
   console.log(`🚀 JustDesk backend running on port ${PORT}`);
-  console.log(`🌍 Environment: ${process.env.NODE_ENV}`);
+  console.log(`🌍 Environment: ${config.app.env}`);
   console.log(`🔗 CORS origins: ${Array.isArray(corsOptions.origin) ? corsOptions.origin.join(', ') : corsOptions.origin}`);
   console.log(`🛡️ Security middleware enabled`);
   console.log(`📊 Active connections tracking: enabled`);


### PR DESCRIPTION
## Summary
- validate required environment variables using Joi
- parse numeric env vars and expose central config
- use config in server for Redis, CORS and port setup

## Testing
- `FRONTEND_URL=http://localhost:3000 npm test` (fails: No tests found for @justdesk/shared)
- `FRONTEND_URL=http://localhost:3000 npm run lint` (fails: frontend and backend lint errors)


------
https://chatgpt.com/codex/tasks/task_e_688cbf9fdc3c832da00b0a04454816dd