### PR TITLE
fix(frontend): handle password submit on key down

### DIFF
--- a/packages/frontend/src/pages/index.js
+++ b/packages/frontend/src/pages/index.js
@@ -116,7 +116,7 @@ export default function Home() {
                   placeholder="Password"
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
-                  onKeyPress={(e) => e.key === 'Enter' && handleConnect()}
+                  onKeyDown={(e) => e.key === 'Enter' && handleConnect()}
                   className="w-full px-4 py-3 bg-white/10 border border-white/20 rounded-xl text-white placeholder-gray-400 focus:outline-none focus:border-green-400 transition-colors"
                 />
               </div>


### PR DESCRIPTION
## Summary
- swap password input to `onKeyDown` and handle Enter key

## Testing
- `npm test` (fails: No tests found for @justdesk/shared)
- `npm run lint` (fails: parsing and prettier errors)


------
https://chatgpt.com/codex/tasks/task_e_688cbfa552c4832daa29980dda90b59b