### PR TITLE
feat(shared): add file transfer events and types

### DIFF
--- a/packages/shared/src/constants.js
+++ b/packages/shared/src/constants.js
@@ -14,6 +14,11 @@ module.exports = {
     OFFER: 'offer',
     ANSWER: 'answer',
     ICE_CANDIDATE: 'ice-candidate',
+
+    // File transfer events
+    FILE_TRANSFER_INIT: 'file-transfer-init',
+    FILE_TRANSFER_CHUNK: 'file-transfer-chunk',
+    FILE_TRANSFER_COMPLETE: 'file-transfer-complete',
     
     // Participant events
     VIEWER_JOINED: 'viewer-joined',

--- a/packages/shared/src/index.js
+++ b/packages/shared/src/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+  ...require('./constants'),
+  ...require('./types')
+};

--- a/packages/shared/src/types.js
+++ b/packages/shared/src/types.js
@@ -59,6 +59,22 @@ const WebRTCTypes = {
   }
 };
 
+// File transfer types
+const FileTransferTypes = {
+  FileMetadata: {
+    name: 'string',
+    size: 'number',
+    mimeType: 'string'
+  },
+
+  FileChunk: {
+    metadata: 'FileMetadata',
+    data: 'ArrayBuffer',
+    chunkIndex: 'number',
+    totalChunks: 'number'
+  }
+};
+
 // API Response types
 const ResponseTypes = {
   SuccessResponse: {
@@ -79,5 +95,6 @@ module.exports = {
   RoomTypes,
   ConnectionTypes,
   WebRTCTypes,
-  ResponseTypes
+  ResponseTypes,
+  FileTransferTypes
 };


### PR DESCRIPTION
## Summary
- add file transfer events to shared constants
- define FileMetadata and FileChunk types
- expose shared constants and types via package index

## Testing
- `cd packages/shared && npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_688f711679a8832dbaf2fc4e2e09ef24