### PR TITLE
feat: add file transfer service for backend

### DIFF
--- a/packages/backend/src/services/fileTransfer.js
+++ b/packages/backend/src/services/fileTransfer.js
@@ -1,0 +1,99 @@
+const { v4: uuidv4 } = require('uuid');
+const logger = require('../utils/logger');
+
+class FileTransferService {
+  constructor(redis, options = {}) {
+    this.redis = redis;
+    this.maxFileSize = options.maxFileSize || 10 * 1024 * 1024; // 10MB
+    this.allowedTypes = options.allowedTypes || ['image/', 'application/pdf', 'text/'];
+    this.prefix = 'file:';
+  }
+
+  async initTransfer({ fileName, fileSize, fileType, from, to }) {
+    if (!fileName || !fileSize || !fileType || !from || !to) {
+      throw new Error('Invalid transfer data');
+    }
+    if (fileSize > this.maxFileSize) {
+      throw new Error('File too large');
+    }
+    if (!this.allowedTypes.some((t) => fileType.startsWith(t))) {
+      throw new Error('Unsupported file type');
+    }
+
+    const transferId = uuidv4();
+    const key = `${this.prefix}${transferId}`;
+
+    await this.redis.hmset(key, {
+      fileName,
+      fileSize,
+      fileType,
+      from,
+      to,
+      received: 0,
+    });
+    await this.redis.expire(key, 60 * 60); // 1 hour TTL
+    await this.redis.del(`${key}:chunks`); // ensure empty list
+    await this.redis.sadd(`${this.prefix}socket:${from}`, transferId);
+    await this.redis.expire(`${this.prefix}socket:${from}`, 60 * 60);
+
+    logger.debug(`File transfer initialized: ${transferId} from ${from} to ${to}`);
+    return transferId;
+  }
+
+  async storeChunk(transferId, chunk) {
+    const key = `${this.prefix}${transferId}`;
+    const meta = await this.redis.hgetall(key);
+    if (!meta || !meta.fileSize) {
+      throw new Error('Transfer not found');
+    }
+    const buffer = Buffer.from(chunk, 'base64');
+    const received = parseInt(meta.received || '0', 10) + buffer.length;
+    if (received > parseInt(meta.fileSize, 10)) {
+      await this.cleanupTransfer(transferId, meta.from);
+      throw new Error('File size mismatch');
+    }
+
+    await this.redis.rpush(`${key}:chunks`, chunk);
+    await this.redis.hset(key, 'received', received);
+  }
+
+  async completeTransfer(transferId) {
+    const key = `${this.prefix}${transferId}`;
+    const meta = await this.redis.hgetall(key);
+    if (!meta) {
+      throw new Error('Transfer not found');
+    }
+
+    const chunks = await this.redis.lrange(`${key}:chunks`, 0, -1);
+    await this.cleanupTransfer(transferId, meta.from);
+
+    return { meta, data: chunks.join('') };
+  }
+
+  async cleanupTransfer(transferId, socketId) {
+    const key = `${this.prefix}${transferId}`;
+    await this.redis.del(key);
+    await this.redis.del(`${key}:chunks`);
+    if (socketId) {
+      await this.redis.srem(`${this.prefix}socket:${socketId}`, transferId);
+    }
+  }
+
+  async cleanupTransfers(socketId) {
+    const setKey = `${this.prefix}socket:${socketId}`;
+    const ids = await this.redis.smembers(setKey);
+    for (const id of ids) {
+      await this.cleanupTransfer(id);
+    }
+    await this.redis.del(setKey);
+  }
+
+  async cleanup() {
+    const keys = await this.redis.keys(`${this.prefix}*`);
+    if (keys.length) {
+      await this.redis.del(keys);
+    }
+  }
+}
+
+module.exports = FileTransferService;

--- a/packages/backend/src/services/signaling.js
+++ b/packages/backend/src/services/signaling.js
@@ -1,29 +1,33 @@
 const { v4: uuidv4 } = require('uuid');
 const logger = require('../utils/logger');
-const roomService = require('./room');
 
 class SignalingService {
-  constructor(io, redis) {
+  constructor(io, redis, fileTransferService, roomService) {
     this.io = io;
     this.redis = redis;
+    this.fileTransferService = fileTransferService;
+    this.roomService = roomService;
     this.connections = new Map();
   }
 
   handleConnection(socket) {
     logger.info(`New socket connection: ${socket.id}`);
-    
+
     socket.on('create-room', (callback) => this.handleCreateRoom(socket, callback));
     socket.on('join-room', (data, callback) => this.handleJoinRoom(socket, data, callback));
     socket.on('leave-room', () => this.handleLeaveRoom(socket));
     socket.on('offer', (data) => this.handleOffer(socket, data));
     socket.on('answer', (data) => this.handleAnswer(socket, data));
     socket.on('ice-candidate', (data) => this.handleIceCandidate(socket, data));
+    socket.on('file-transfer-init', (data, cb) => this.handleFileTransferInit(socket, data, cb));
+    socket.on('file-transfer-chunk', (data) => this.handleFileTransferChunk(socket, data));
+    socket.on('file-transfer-complete', (data) => this.handleFileTransferComplete(socket, data));
     socket.on('disconnect', () => this.handleDisconnect(socket));
   }
 
   async handleCreateRoom(socket, callback) {
     try {
-      const room = await roomService.createRoom(socket.id);
+      const room = await this.roomService.createRoom(socket.id);
       
       socket.join(room.roomId);
       this.connections.set(socket.id, {
@@ -49,7 +53,7 @@ class SignalingService {
 
   async handleJoinRoom(socket, { roomId, password }, callback) {
     try {
-      const room = await roomService.getRoom(roomId);
+      const room = await this.roomService.getRoom(roomId);
       
       if (!room) {
         callback({
@@ -67,7 +71,7 @@ class SignalingService {
         return;
       }
 
-      const result = await roomService.joinRoom(roomId, socket.id);
+      const result = await this.roomService.joinRoom(roomId, socket.id);
       
       if (!result.success) {
         callback({
@@ -111,10 +115,10 @@ class SignalingService {
     const { roomId, role } = connection;
     
     if (role === 'viewer') {
-      await roomService.leaveRoom(roomId, socket.id);
+      await this.roomService.leaveRoom(roomId, socket.id);
       
       // Notify host
-      const room = await roomService.getRoom(roomId);
+      const room = await this.roomService.getRoom(roomId);
       if (room) {
         socket.to(room.hostId).emit('viewer-left', {
           viewerId: socket.id
@@ -152,6 +156,61 @@ class SignalingService {
     });
   }
 
+  async handleFileTransferInit(socket, data, callback) {
+    try {
+      const transferId = await this.fileTransferService.initTransfer({
+        ...data,
+        from: socket.id,
+      });
+      socket.to(data.to).emit('file-transfer-init', {
+        transferId,
+        fileName: data.fileName,
+        fileSize: data.fileSize,
+        fileType: data.fileType,
+        from: socket.id,
+      });
+      if (callback) callback({ success: true, transferId });
+    } catch (error) {
+      logger.error('File transfer init error:', error);
+      if (callback) callback({ success: false, error: error.message });
+    }
+  }
+
+  async handleFileTransferChunk(socket, { transferId, chunk, to }) {
+    try {
+      await this.fileTransferService.storeChunk(transferId, chunk);
+      socket.to(to).emit('file-transfer-chunk', {
+        transferId,
+        chunk,
+        from: socket.id,
+      });
+    } catch (error) {
+      logger.error('File transfer chunk error:', error);
+      socket.emit('file-transfer-error', {
+        transferId,
+        error: error.message,
+      });
+    }
+  }
+
+  async handleFileTransferComplete(socket, { transferId, to }) {
+    try {
+      const { meta, data } = await this.fileTransferService.completeTransfer(transferId);
+      socket.to(to).emit('file-transfer-complete', {
+        transferId,
+        from: socket.id,
+        meta,
+        data,
+      });
+    } catch (error) {
+      logger.error('File transfer complete error:', error);
+      socket.emit('file-transfer-error', {
+        transferId,
+        error: error.message,
+      });
+    }
+  }
+
   async handleDisconnect(socket) {
     logger.info(`Socket disconnected: ${socket.id}`);
     
@@ -162,7 +221,7 @@ class SignalingService {
     
     if (role === 'host') {
       // Host disconnected, close the room
-      await roomService.closeRoom(roomId);
+      await this.roomService.closeRoom(roomId);
       this.io.to(roomId).emit('host-disconnected');
       
       // Disconnect all viewers
@@ -177,16 +236,17 @@ class SignalingService {
       logger.info(`Room ${roomId} closed due to host disconnect`);
     } else if (role === 'viewer') {
       // Viewer disconnected
-      await roomService.leaveRoom(roomId, socket.id);
+      await this.roomService.leaveRoom(roomId, socket.id);
       
-      const room = await roomService.getRoom(roomId);
+      const room = await this.roomService.getRoom(roomId);
       if (room) {
         socket.to(room.hostId).emit('viewer-disconnected', {
           viewerId: socket.id
         });
       }
     }
-    
+
+    await this.fileTransferService.cleanupTransfers(socket.id);
     this.connections.delete(socket.id);
   }
 }


### PR DESCRIPTION
## Summary
- add FileTransferService for chunked uploads stored in Redis
- wire SignalingService and server to forward file transfer events
- clean up temporary transfer data on socket disconnect and shutdown

## Testing
- `npm test`
- `npm run lint` *(fails: prettier/prettier errors)*

------
https://chatgpt.com/codex/tasks/task_e_688f71173464832dab24702744ce4d4e