### PR TITLE
feat: add file transfer component and hook

### DIFF
--- a/packages/frontend/src/components/FileTransfer.js
+++ b/packages/frontend/src/components/FileTransfer.js
@@ -1,0 +1,50 @@
+import { useState } from 'react';
+import { Upload, File as FileIcon } from 'lucide-react';
+import useFileTransfer from '../hooks/useFileTransfer';
+
+export default function FileTransfer({ socket, peers }) {
+  const { sendFile, progress, receivedFiles } = useFileTransfer(socket, peers);
+  const [selected, setSelected] = useState(null);
+
+  const handleSend = () => {
+    if (selected) {
+      sendFile(selected);
+      setSelected(null);
+    }
+  };
+
+  return (
+    <div className="bg-black/40 backdrop-blur rounded-lg p-4 mt-4 text-white">
+      <div className="flex items-center space-x-2 mb-4">
+        <input type="file" onChange={(e) => setSelected(e.target.files[0])} className="text-sm" />
+        <button
+          onClick={handleSend}
+          disabled={!selected}
+          className="px-3 py-1 bg-blue-600 disabled:opacity-50 rounded flex items-center"
+        >
+          <Upload className="w-4 h-4 mr-1" /> Send
+        </button>
+      </div>
+      {progress > 0 && progress < 100 && (
+        <div className="w-full bg-gray-700 rounded h-2 mb-4">
+          <div className="bg-blue-500 h-2 rounded" style={{ width: `${progress}%` }} />
+        </div>
+      )}
+      {receivedFiles.length > 0 && (
+        <div>
+          <h3 className="font-semibold mb-2">Received Files</h3>
+          <ul className="space-y-1">
+            {receivedFiles.map((file) => (
+              <li key={file.id} className="flex items-center space-x-2">
+                <FileIcon className="w-4 h-4" />
+                <a href={file.url} download={file.name} className="text-blue-300 underline">
+                  {file.name}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/frontend/src/hooks/useFileTransfer.js
+++ b/packages/frontend/src/hooks/useFileTransfer.js
@@ -1,0 +1,132 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { EVENTS } from '@justdesk/shared/src/constants';
+
+const CHUNK_SIZE = 16 * 1024; // 16KB
+
+export default function useFileTransfer(socket, peers = {}) {
+  const [progress, setProgress] = useState(0);
+  const [receivedFiles, setReceivedFiles] = useState([]);
+  const incomingFiles = useRef({});
+
+  // handle incoming messages via socket
+  useEffect(() => {
+    if (!socket) return;
+    const handleMessage = (message) => {
+      processMessage(message);
+    };
+    socket.on(EVENTS.FILE_META, handleMessage);
+    socket.on(EVENTS.FILE_CHUNK, handleMessage);
+    socket.on(EVENTS.FILE_COMPLETE, handleMessage);
+    return () => {
+      socket.off(EVENTS.FILE_META, handleMessage);
+      socket.off(EVENTS.FILE_CHUNK, handleMessage);
+      socket.off(EVENTS.FILE_COMPLETE, handleMessage);
+    };
+  }, [socket]);
+
+  // handle incoming messages via data channels
+  useEffect(() => {
+    const peersArray = Object.values(peers || {});
+    if (peersArray.length === 0) return;
+    const handlers = [];
+    peersArray.forEach((peer) => {
+      const handler = (data) => {
+        try {
+          const message =
+            typeof data === 'string'
+              ? JSON.parse(data)
+              : JSON.parse(new TextDecoder().decode(data));
+          processMessage(message);
+        } catch (e) {
+          // ignore parse errors
+        }
+      };
+      peer.on('data', handler);
+      handlers.push({ peer, handler });
+    });
+    return () => {
+      handlers.forEach(({ peer, handler }) => peer.off('data', handler));
+    };
+  }, [peers]);
+
+  const broadcast = useCallback(
+    (message) => {
+      const payload = JSON.stringify(message);
+      const peersArray = Object.values(peers || {});
+      if (peersArray.length > 0) {
+        peersArray.forEach((peer) => {
+          try {
+            peer.send(payload);
+          } catch (e) {
+            // ignore send errors
+          }
+        });
+      } else if (socket) {
+        const event =
+          message.type === 'meta'
+            ? EVENTS.FILE_META
+            : message.type === 'chunk'
+              ? EVENTS.FILE_CHUNK
+              : EVENTS.FILE_COMPLETE;
+        socket.emit(event, message);
+      }
+    },
+    [peers, socket]
+  );
+
+  const sendFile = useCallback(
+    (file) => {
+      const id = Date.now().toString();
+      setProgress(0);
+      broadcast({ type: 'meta', id, name: file.name, size: file.size });
+
+      let offset = 0;
+      const reader = new FileReader();
+      reader.onload = (e) => {
+        const chunk = Array.from(new Uint8Array(e.target.result));
+        const base64 = btoa(String.fromCharCode.apply(null, chunk));
+        offset += e.target.result.byteLength;
+        broadcast({ type: 'chunk', id, data: base64 });
+        setProgress(Math.round((offset / file.size) * 100));
+        if (offset < file.size) {
+          readSlice();
+        } else {
+          broadcast({ type: 'complete', id });
+          setProgress(100);
+        }
+      };
+      const readSlice = () => {
+        const slice = file.slice(offset, offset + CHUNK_SIZE);
+        reader.readAsArrayBuffer(slice);
+      };
+      readSlice();
+    },
+    [broadcast]
+  );
+
+  const processMessage = useCallback((message) => {
+    const { type, id, name, size, data } = message;
+    if (type === 'meta') {
+      incomingFiles.current[id] = { name, size, chunks: [] };
+    } else if (type === 'chunk') {
+      if (incomingFiles.current[id]) {
+        incomingFiles.current[id].chunks.push(data);
+      }
+    } else if (type === 'complete') {
+      const fileData = incomingFiles.current[id];
+      if (fileData) {
+        const binaryString = atob(fileData.chunks.join(''));
+        const len = binaryString.length;
+        const bytes = new Uint8Array(len);
+        for (let i = 0; i < len; i++) {
+          bytes[i] = binaryString.charCodeAt(i);
+        }
+        const url = URL.createObjectURL(new Blob([bytes]));
+        setReceivedFiles((prev) => [...prev, { id, name: fileData.name, url }]);
+        delete incomingFiles.current[id];
+      }
+    }
+  }, []);
+
+  return { sendFile, progress, receivedFiles };
+}

--- a/packages/frontend/src/pages/share.js
+++ b/packages/frontend/src/pages/share.js
@@ -5,6 +5,7 @@ import { Wifi, Users, AlertCircle, Monitor, Clock } from 'lucide-react';
 import Layout from '../components/Layout';
 import ScreenShare from '../components/ScreenShare';
 import ConnectionPanel from '../components/ConnectionPanel';
+import FileTransfer from '../components/FileTransfer';
 import useWebRTC from '../hooks/useWebRTC';
 import useSocket from '../hooks/useSocket';
 import ViewerChart from '../components/ViewerChart';
@@ -23,7 +24,7 @@ export default function ShareScreen() {
   const [viewerStats, setViewerStats] = useState([]);
 
   const { socket, connected } = useSocket();
-  const { startScreenShare, stopScreenShare, stream } = useWebRTC(socket);
+  const { startScreenShare, stopScreenShare, stream, peers } = useWebRTC(socket);
 
   useEffect(() => {
     if (connected && !roomId && !isCreatingRoom) {
@@ -334,6 +335,7 @@ export default function ShareScreen() {
                   sharingStartTime={sharingStartTime}
                 />
                 <ViewerChart data={viewerStats} />
+                <FileTransfer socket={socket} peers={peers} />
               </div>
             </div>
           </div>

--- a/packages/frontend/src/pages/view.js
+++ b/packages/frontend/src/pages/view.js
@@ -4,6 +4,7 @@ import Head from 'next/head';
 import { Monitor, Loader, XCircle, Maximize, Volume2 } from 'lucide-react';
 import Layout from '../components/Layout';
 import RemoteViewer from '../components/RemoteViewer';
+import FileTransfer from '../components/FileTransfer';
 import useWebRTC from '../hooks/useWebRTC';
 import useSocket from '../hooks/useSocket';
 
@@ -19,7 +20,7 @@ export default function ViewScreen() {
   const [nicknameSubmitted, setNicknameSubmitted] = useState(false);
 
   const { socket } = useSocket();
-  const { remoteStream, connectToPeer } = useWebRTC(socket);
+  const { remoteStream, peers } = useWebRTC(socket);
 
   // Handle router query in useEffect to avoid SSR issues
   useEffect(() => {
@@ -181,7 +182,10 @@ export default function ViewScreen() {
               </div>
             </div>
           ) : (
-            <RemoteViewer stream={remoteStream} connected={connected} roomId={roomId} />
+            <>
+              <RemoteViewer stream={remoteStream} connected={connected} roomId={roomId} />
+              <FileTransfer socket={socket} peers={peers} />
+            </>
           )}
         </div>
       </div>

--- a/packages/shared/src/constants.js
+++ b/packages/shared/src/constants.js
@@ -9,24 +9,29 @@ module.exports = {
     ROOM_JOINED: 'room-joined',
     ROOM_LEFT: 'room-left',
     ROOM_CLOSED: 'room-closed',
-    
+
     // WebRTC events
     OFFER: 'offer',
     ANSWER: 'answer',
     ICE_CANDIDATE: 'ice-candidate',
-    
+
     // Participant events
     VIEWER_JOINED: 'viewer-joined',
     VIEWER_LEFT: 'viewer-left',
     VIEWER_DISCONNECTED: 'viewer-disconnected',
     HOST_DISCONNECTED: 'host-disconnected',
-    
+
+    // File transfer events
+    FILE_META: 'file-meta',
+    FILE_CHUNK: 'file-chunk',
+    FILE_COMPLETE: 'file-complete',
+
     // Error events
     ERROR: 'error',
     CONNECTION_ERROR: 'connection-error',
-    ROOM_ERROR: 'room-error'
+    ROOM_ERROR: 'room-error',
   },
-  
+
   // Room constraints
   ROOM: {
     MAX_VIEWERS: 10,
@@ -34,25 +39,25 @@ module.exports = {
     PASSWORD_LENGTH: 6,
     SESSION_TIMEOUT: 3600000, // 1 hour in milliseconds
     MIN_ID: 100000000,
-    MAX_ID: 999999999
+    MAX_ID: 999999999,
   },
-  
+
   // WebRTC constraints
   WEBRTC: {
     VIDEO: {
       MAX_WIDTH: 1920,
       MAX_HEIGHT: 1080,
       MAX_FRAMERATE: 30,
-      MIN_FRAMERATE: 15
+      MIN_FRAMERATE: 15,
     },
     AUDIO: {
       ECHO_CANCELLATION: true,
       NOISE_SUPPRESSION: true,
       AUTO_GAIN_CONTROL: true,
-      SAMPLE_RATE: 44100
-    }
+      SAMPLE_RATE: 44100,
+    },
   },
-  
+
   // Error codes
   ERROR_CODES: {
     ROOM_NOT_FOUND: 'ROOM_NOT_FOUND',
@@ -62,21 +67,21 @@ module.exports = {
     CONNECTION_FAILED: 'CONNECTION_FAILED',
     WEBRTC_ERROR: 'WEBRTC_ERROR',
     SERVER_ERROR: 'SERVER_ERROR',
-    RATE_LIMIT_EXCEEDED: 'RATE_LIMIT_EXCEEDED'
+    RATE_LIMIT_EXCEEDED: 'RATE_LIMIT_EXCEEDED',
   },
-  
+
   // Connection states
   CONNECTION_STATES: {
     CONNECTING: 'connecting',
     CONNECTED: 'connected',
     DISCONNECTED: 'disconnected',
     FAILED: 'failed',
-    CLOSED: 'closed'
+    CLOSED: 'closed',
   },
-  
+
   // User roles
   ROLES: {
     HOST: 'host',
-    VIEWER: 'viewer'
-  }
+    VIEWER: 'viewer',
+  },
 };


### PR DESCRIPTION
## Summary
- add file transfer hook using WebRTC data channel or socket.io
- create FileTransfer component with picker, progress and download
- integrate file transfer into view and share pages

## Testing
- `npm test` *(fails: No tests found for @justdesk/shared)*
- `npm run lint` *(fails: parsing errors in existing frontend files)*

------
https://chatgpt.com/codex/tasks/task_e_688f7117d080832d9a4ac3a0ea52a7e0