### PR TITLE
feat: refine viewer stats window

### DIFF
--- a/packages/frontend/src/components/ViewerChart.js
+++ b/packages/frontend/src/components/ViewerChart.js
@@ -33,7 +33,7 @@ const CustomTooltip = ({ active, payload, label }) => {
 export default function ViewerChart({ data }) {
   return (
     <div className="bg-white/10 backdrop-blur-lg rounded-2xl p-4 border border-white/20 h-64">
-      <h3 className="text-lg font-semibold text-white mb-4">Viewer Analytics (last 60 min)</h3>
+      <h3 className="text-lg font-semibold text-white mb-4">Viewer Analytics (first hour)</h3>
       <ResponsiveContainer width="100%" height="100%">
         <LineChart data={data}>
           <CartesianGrid strokeDasharray="3 3" stroke="#555" />


### PR DESCRIPTION
## Summary
- use room's `sharingStartTime` as basis for viewer stats, building 60-min window from stream start
- preserve initial hour events and prevent premature cleanup in `logViewerEvent`
- clarify chart heading to show data covers first hour

## Testing
- `npx lerna run test -- --passWithNoTests`
- `npm run lint` *(fails: Parsing error: Unexpected token <)*

------
https://chatgpt.com/codex/tasks/task_e_689096f96128832dacc84a6ce891913c