### PR TITLE
feat: show current viewer names in stats

### DIFF
--- a/packages/backend/src/services/room.js
+++ b/packages/backend/src/services/room.js
@@ -120,16 +120,24 @@ class RoomService {
 
     const stats = [];
     let viewerCount = 0;
+    const currentViewers = new Map();
 
     // Initial data point with zero viewers at sharing start
-    stats.push({ timestamp: sharingStartTime, count: 0 });
+    stats.push({ timestamp: sharingStartTime, count: 0, events: [], viewers: [] });
 
     for (const event of events) {
-      viewerCount += event.action === 'join' ? 1 : -1;
+      if (event.action === 'join') {
+        viewerCount += 1;
+        currentViewers.set(event.viewerId, event.nickname);
+      } else {
+        viewerCount -= 1;
+        currentViewers.delete(event.viewerId);
+      }
       stats.push({
         timestamp: event.timestamp,
         count: viewerCount,
-        event: { nickname: event.nickname, action: event.action },
+        events: [{ nickname: event.nickname, action: event.action }],
+        viewers: Array.from(currentViewers.values()),
       });
     }
 

--- a/packages/frontend/src/components/ViewerChart.js
+++ b/packages/frontend/src/components/ViewerChart.js
@@ -10,7 +10,7 @@ import {
 
 const CustomTooltip = ({ active, payload, label }) => {
   if (active && payload && payload.length) {
-    const { count, events } = payload[0].payload;
+    const { count, events, viewers } = payload[0].payload;
     return (
       <div className="bg-gray-800 p-2 rounded text-white text-sm">
         <p className="font-semibold">{label}</p>
@@ -24,6 +24,14 @@ const CustomTooltip = ({ active, payload, label }) => {
             ))}
           </div>
         )}
+        {viewers && viewers.length > 0 && (
+          <div className="mt-2">
+            <div className="font-semibold">Currently present</div>
+            {viewers.map((v, i) => (
+              <div key={i}>{v || 'Anon'}</div>
+            ))}
+          </div>
+        )}
       </div>
     );
   }
@@ -34,7 +42,7 @@ export default function ViewerChart({ data = [] }) {
   const chartData =
     data.length > 0 && data[0].count === 0
       ? data
-      : [{ time: data[0]?.time ?? '', count: 0 }, ...data];
+      : [{ time: data[0]?.time ?? '', count: 0, events: [], viewers: [] }, ...data];
 
   return (
     <div className="bg-white/10 backdrop-blur-lg rounded-2xl p-4 border border-white/20 h-64">

--- a/packages/frontend/src/pages/share.js
+++ b/packages/frontend/src/pages/share.js
@@ -47,6 +47,7 @@ export default function ShareScreen() {
             }),
             count: s.count,
             events: s.events,
+            viewers: s.viewers,
           }));
           setViewerStats(formatted);
         })
@@ -61,6 +62,7 @@ export default function ShareScreen() {
         time: new Date(s.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
         count: s.count,
         events: s.events,
+        viewers: s.viewers,
       }));
       setViewerStats(formatted);
     };


### PR DESCRIPTION
## Summary
- track current viewer names in `getViewerStats`
- pass viewer lists to share page analytics
- show currently present viewers in chart tooltip

## Testing
- `npm test` *(fails: No tests found in /workspace/JustDesk/packages/shared)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890b19587a8832d99517b341401b27d