### PR TITLE
fix: build frontend image with workspace context

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -10,6 +10,8 @@ on:
 permissions:
   contents: read
   security-events: write
+env:
+  GITHUB_TOKEN: ${{ secrets.TOKEN }}
 jobs:
   security-scan:
     runs-on: ubuntu-latest
@@ -64,7 +66,7 @@ jobs:
     
     - name: Build Docker images
       run: |
-        docker build -t justdesk-frontend ./packages/frontend
+        docker build -t justdesk-frontend -f packages/frontend/Dockerfile .
         docker build -t justdesk-backend ./packages/backend
     
     - name: Run Trivy on Docker images
@@ -73,6 +75,3 @@ jobs:
           aquasec/trivy image justdesk-frontend
         docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
           aquasec/trivy image justdesk-backend
-  
-  env:
-  GITHUB_TOKEN: ${{ secrets.TOKEN }}

--- a/packages/frontend/Dockerfile
+++ b/packages/frontend/Dockerfile
@@ -3,14 +3,20 @@ FROM node:18-alpine AS builder
 
 WORKDIR /app
 
-# Copy package files
-COPY package*.json ./
-RUN npm install
+# Copy workspace package manifests
+COPY package.json package-lock.json ./
+COPY packages/shared/package.json packages/shared/
+COPY packages/frontend/package.json packages/frontend/
+
+# Install dependencies for workspaces
+RUN npm install --workspaces
 
 # Copy source files
-COPY . .
+COPY packages/shared packages/shared
+COPY packages/frontend packages/frontend
 
 # Build the application
+WORKDIR /app/packages/frontend
 RUN npm run build
 
 # Production stage
@@ -19,13 +25,12 @@ FROM node:18-alpine AS runner
 WORKDIR /app
 
 # Create non-root user
-RUN addgroup -g 1001 -S nodejs
-RUN adduser -S nextjs -u 1001
+RUN addgroup -g 1001 -S nodejs && adduser -S nextjs -u 1001
 
 # Copy built application
-COPY --from=builder /app/public ./public
-COPY --from=builder /app/.next/standalone ./
-COPY --from=builder /app/.next/static ./.next/static
+COPY --from=builder /app/packages/frontend/public ./public
+COPY --from=builder /app/packages/frontend/.next/standalone ./
+COPY --from=builder /app/packages/frontend/.next/static ./.next/static
 
 # Set ownership
 RUN chown -R nextjs:nodejs /app
@@ -34,7 +39,8 @@ USER nextjs
 
 EXPOSE 3000
 
-ENV PORT 3000
-ENV NODE_ENV production
+ENV PORT=3000
+ENV NODE_ENV=production
 
 CMD ["node", "server.js"]
+


### PR DESCRIPTION
## Summary
- fix syntax of security workflow by adding top-level env
- build frontend Docker image from repo root so workspace dependencies resolve

## Testing
- `npm test`
- `npm run lint`
- `docker build -t test-frontend -f packages/frontend/Dockerfile .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_6890c5484ae4832d8ab7ccbdda5ebfdd