### PR TITLE
ci: add backend build fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,3 +234,11 @@ jobs:
         context: ./packages/frontend
         push: false
         tags: justdesk-frontend:latest
+
+    - name: Build backend only (no push)
+      uses: docker/build-push-action@v5
+      if: steps.check-secrets.outputs.has-secrets == 'false'
+      with:
+        context: ./packages/backend
+        push: false
+        tags: justdesk-backend:latest


### PR DESCRIPTION
## Summary
- build backend image locally when Docker credentials are missing
- tag backend image `justdesk-backend:latest` alongside frontend fallback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a067ba660832da9db675bdf4243ab