### PR TITLE
Fix frontend Docker build context in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,8 @@ jobs:
       uses: docker/build-push-action@v5
       if: steps.check-secrets.outputs.has-secrets == 'true'
       with:
-        context: ./packages/frontend
+        context: .
+        file: ./packages/frontend/Dockerfile
         push: true
         tags: |
           ${{ secrets.DOCKER_USERNAME }}/justdesk-frontend:latest
@@ -199,7 +200,8 @@ jobs:
       uses: docker/build-push-action@v5
       if: steps.check-secrets.outputs.has-secrets == 'false'
       with:
-        context: ./packages/frontend
+        context: .
+        file: ./packages/frontend/Dockerfile
         push: false
         tags: justdesk-frontend:latest
 


### PR DESCRIPTION
## Summary
- fix frontend Docker build by pointing workflow to repo root context and frontend Dockerfile

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a0a771394832d8ce5f41284ee9201