### PR TITLE
fix: update Dockerfile copy paths for frontend build

### DIFF
--- a/packages/frontend/Dockerfile
+++ b/packages/frontend/Dockerfile
@@ -26,9 +26,9 @@ RUN addgroup -g 1001 -S nodejs \
  && adduser -S nextjs -u 1001
 
 # Build sonrası dosyaları al
-COPY --from=builder /app/public            ./public
-COPY --from=builder /app/.next/standalone  ./
-COPY --from=builder /app/.next/static      ./.next/static
+COPY --from=builder /app/packages/frontend/public           ./public
+COPY --from=builder /app/packages/frontend/.next/standalone ./
+COPY --from=builder /app/packages/frontend/.next/static     ./.next/static
 
 # Sahiplik ayarları
 RUN chown -R nextjs:nodejs /app


### PR DESCRIPTION
## Summary
- adjust frontend production image COPY paths to reference workspace package directories

## Testing
- `npm test`
- `docker build packages/frontend` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_689a0cd2ee00832d852a6306b38d9857