### PR TITLE
refactor: use centralized logger in backend

### DIFF
--- a/packages/backend/src/config/index.js
+++ b/packages/backend/src/config/index.js
@@ -20,12 +20,7 @@ const envSchema = Joi.object({
 
 const { value: env, error } = envSchema.validate(process.env, { abortEarly: false });
 
-if (error) {
-  console.error('❌ Environment validation error:', error.details.map(d => d.message).join(', '));
-  process.exit(1);
-}
-
-module.exports = {
+const config = {
   app: {
     env: env.NODE_ENV,
     port: parseInt(env.PORT, 10),
@@ -71,4 +66,12 @@ module.exports = {
     file: env.LOG_FILE
   }
 };
+
+module.exports = config;
+
+if (error) {
+  const logger = require('../utils/logger');
+  logger.error('❌ Environment validation error:', error.details.map(d => d.message).join(', '));
+  process.exit(1);
+}
 

--- a/packages/backend/src/routes/analytics.js
+++ b/packages/backend/src/routes/analytics.js
@@ -2,6 +2,7 @@ const express = require('express');
 const { apiLimiter } = require('../middleware/rateLimit');
 const RoomService = require('../services/room');
 const { redis } = require('../utils/redis');
+const logger = require('../utils/logger');
 
 const router = express.Router();
 const roomService = new RoomService(redis);
@@ -14,10 +15,10 @@ router.get('/rooms/:roomId/analytics', apiLimiter, async (req, res) => {
   try {
     const stats = await roomService.getViewerStats(roomId);
     res.json({ stats });
-  } catch (error) {
-    console.error('Viewer analytics error:', error);
-    res.status(500).json({ error: 'Failed to get analytics' });
-  }
-});
+    } catch (error) {
+      logger.error('Viewer analytics error:', error);
+      res.status(500).json({ error: 'Failed to get analytics' });
+    }
+  });
 
 module.exports = router;

--- a/packages/backend/src/routes/health.js
+++ b/packages/backend/src/routes/health.js
@@ -2,6 +2,7 @@ const express = require('express');
 const { healthLimiter } = require('../middleware/rateLimit');
 const { getRedisHealth } = require('../utils/redis');
 const connections = require('../utils/connections');
+const logger = require('../utils/logger');
 
 const router = express.Router();
 
@@ -27,14 +28,14 @@ router.get('/health', healthLimiter, async (req, res) => {
     });
 
     res.json(healthData);
-  } catch (error) {
-    console.error('Health check error:', error);
-    res.status(503).json({
-      status: 'error',
-      timestamp: new Date().toISOString(),
-      error: 'Health check failed',
-    });
-  }
-});
+    } catch (error) {
+      logger.error('Health check error:', error);
+      res.status(503).json({
+        status: 'error',
+        timestamp: new Date().toISOString(),
+        error: 'Health check failed',
+      });
+    }
+  });
 
 module.exports = router;

--- a/packages/backend/src/routes/room.js
+++ b/packages/backend/src/routes/room.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const { strictLimiter } = require('../middleware/rateLimit');
 const { redis } = require('../utils/redis');
+const logger = require('../utils/logger');
 
 const router = express.Router();
 
@@ -29,10 +30,10 @@ router.get('/room/:roomId', strictLimiter, async (req, res) => {
       sharingStartTime: room.sharingStartTime,
       isSharing: room.isSharing || false,
     });
-  } catch (error) {
-    console.error('Room info error:', error);
-    res.status(500).json({ error: 'Failed to get room info' });
-  }
-});
+    } catch (error) {
+      logger.error('Room info error:', error);
+      res.status(500).json({ error: 'Failed to get room info' });
+    }
+  });
 
 module.exports = router;

--- a/packages/backend/src/utils/redis.js
+++ b/packages/backend/src/utils/redis.js
@@ -1,5 +1,6 @@
 const Redis = require('ioredis');
 const config = require('../config');
+const logger = require('./logger');
 
 let redis;
 let redisHealthCache = {
@@ -12,7 +13,7 @@ try {
   if (config.redis.url) {
     redis = new Redis(config.redis.url, {
       retryStrategy: (times) => {
-        console.log(`Redis retry attempt ${times}`);
+          logger.warn(`Redis retry attempt ${times}`);
         return Math.min(times * 50, 2000);
       },
       maxRetriesPerRequest: 3,
@@ -26,37 +27,37 @@ try {
       port: config.redis.port,
       password: config.redis.password,
       retryStrategy: (times) => {
-        console.log(`Redis retry attempt ${times}`);
+          logger.warn(`Redis retry attempt ${times}`);
         return Math.min(times * 50, 2000);
       },
     });
   }
 
-  redis.on('connect', () => {
-    console.log('✅ Redis connected successfully');
-    redisHealthCache.status = 'connected';
-    redisHealthCache.lastCheck = Date.now();
-  });
+    redis.on('connect', () => {
+      logger.info('✅ Redis connected successfully');
+      redisHealthCache.status = 'connected';
+      redisHealthCache.lastCheck = Date.now();
+    });
 
-  redis.on('ready', () => {
-    console.log('✅ Redis ready to accept commands');
-  });
+    redis.on('ready', () => {
+      logger.info('✅ Redis ready to accept commands');
+    });
 
-  redis.on('error', (err) => {
-    console.error('❌ Redis connection error:', err.message);
-    redisHealthCache.status = 'error: ' + err.message;
-    redisHealthCache.lastCheck = Date.now();
-  });
+    redis.on('error', (err) => {
+      logger.error('❌ Redis connection error:', err.message);
+      redisHealthCache.status = 'error: ' + err.message;
+      redisHealthCache.lastCheck = Date.now();
+    });
 
-  redis.on('reconnecting', () => {
-    console.log('🔄 Redis reconnecting...');
-    redisHealthCache.status = 'reconnecting';
-    redisHealthCache.lastCheck = Date.now();
-  });
-} catch (error) {
-  console.error('❌ Redis initialization error:', error);
-  redisHealthCache.status = 'initialization error';
-}
+    redis.on('reconnecting', () => {
+      logger.warn('🔄 Redis reconnecting...');
+      redisHealthCache.status = 'reconnecting';
+      redisHealthCache.lastCheck = Date.now();
+    });
+  } catch (error) {
+    logger.error('❌ Redis initialization error:', error);
+    redisHealthCache.status = 'initialization error';
+  }
 
 async function getRedisHealth() {
   const now = Date.now();


### PR DESCRIPTION
## Summary
- replace console logging in server, redis, sockets, and routes with shared logger
- validate env config using logger when misconfigured

## Testing
- `node -e "process.env.FRONTEND_URL='http://localhost:3000'; const logger=require('./packages/backend/src/utils/logger'); logger.info('Info log test'); logger.error('Error log test');"`
- `FRONTEND_URL=http://localhost npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a67b46ea4832d8d9fcd11c0bf4b5c