### PR TITLE
docs: add changelog and link from index

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+## 2025-08-11
+### Added
+- Created initial changelog to track significant changes after each release or commit.

--- a/docs/index.html
+++ b/docs/index.html
@@ -84,6 +84,10 @@
     </thead>
     <tbody>
       <tr>
+        <td><a href="CHANGELOG.html">CHANGELOG</a></td>
+        <td>Record of significant changes for each release and commit.</td>
+      </tr>
+      <tr>
         <td><a href="API.html">API</a></td>
         <td>Detailed explanation of the application's API endpoints.</td>
       </tr>

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@ Bu dökümantasyon, projeyi kurmak, çalıştırmak ve sorun gidermek için ihti
 
 | Belge | Açıklama |
 |-------|----------|
+| [CHANGELOG.md](CHANGELOG.md) | Projedeki önemli değişikliklerin kaydı. |
 | [API.md](API.md) | Uygulamanın sunduğu API uç noktalarının detaylı açıklamaları. |
 | [ARCHITECTURE.md](ARCHITECTURE.md) | JustDesk’in sistem mimarisi ve bileşen yapısı hakkında genel bilgi. |
 | [DEPLOYMENT.md](DEPLOYMENT.md) | Sunucuya kurulum ve dağıtım adımları. |


### PR DESCRIPTION
## Summary
- add CHANGELOG.md for tracking notable updates
- link changelog from documentation index pages

## Testing
- `npm test`
- `npm run lint` *(fails: Running target lint for 2 projects failed - @justdesk/backend:lint)*
- `npx marked -i docs/CHANGELOG.md -o docs/CHANGELOG.html`
- `curl -I https://justtechcom.github.io/JustDesk/CHANGELOG.html` *(404 Not Found)*

------
https://chatgpt.com/codex/tasks/task_e_689a6a05858c832d92ecaeb849c61264