### PR TITLE
feat(backend): sanitize request bodies with xss

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6887,6 +6887,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/cssfilter": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
+      "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw==",
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
@@ -20419,6 +20425,28 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/xss": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.15.tgz",
+      "integrity": "sha512-FVdlVVC67WOIPvfOwhoMETV72f6GbW7aOabBC3WxN/oUdoEMDyLz4OgRv5/gck2ZeNqEQu+Tb0kloovXOfpYVg==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^2.20.3",
+        "cssfilter": "0.0.10"
+      },
+      "bin": {
+        "xss": "bin/xss"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/xss/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
+    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -20532,7 +20560,8 @@
         "joi": "^17.11.0",
         "socket.io": "^4.6.1",
         "uuid": "^9.0.1",
-        "winston": "^3.11.0"
+        "winston": "^3.11.0",
+        "xss": "^1.0.15"
       },
       "devDependencies": {
         "eslint": "^8.54.0",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -21,7 +21,8 @@
     "joi": "^17.11.0",
     "socket.io": "^4.6.1",
     "uuid": "^9.0.1",
-    "winston": "^3.11.0"
+    "winston": "^3.11.0",
+    "xss": "^1.0.15"
   },
   "devDependencies": {
     "eslint": "^8.54.0",

--- a/packages/backend/src/middleware/security.js
+++ b/packages/backend/src/middleware/security.js
@@ -1,5 +1,6 @@
 const helmet = require('helmet');
 const compression = require('compression');
+const xss = require('xss');
 
 // Security middleware setup
 const securityMiddleware = [
@@ -45,11 +46,10 @@ const securityMiddleware = [
   
   // Request sanitization
   (req, res, next) => {
-    // Remove any potential XSS attempts from common fields
     if (req.body) {
       Object.keys(req.body).forEach(key => {
         if (typeof req.body[key] === 'string') {
-          req.body[key] = req.body[key].replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '');
+          req.body[key] = xss(req.body[key]);
         }
       });
     }


### PR DESCRIPTION
## Summary
- replace regex-based sanitization with `xss` library
- add `xss` dependency for backend package

## Testing
- `npm install`
- `npm test -w packages/backend`


------
https://chatgpt.com/codex/tasks/task_e_689ad4367500832d98a310f45860c66f