### PR TITLE
Enable changelog workflow push

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -6,6 +6,9 @@ on:
       - main
       - master
 
+permissions:
+  contents: write
+
 jobs:
   changelog:
     if: "!contains(github.event.head_commit.message, 'skip changelog')"

--- a/packages/backend/src/utils/redis.js
+++ b/packages/backend/src/utils/redis.js
@@ -3,7 +3,7 @@ const config = require('../config');
 const logger = require('./logger');
 
 let redis;
-let redisHealthCache = {
+const redisHealthCache = {
   status: 'unknown',
   lastCheck: 0,
   cacheDuration: 30000, // 30 seconds cache


### PR DESCRIPTION
## Summary
- allow changelog workflow to push by granting `contents: write`
- fix redis cache declaration to satisfy lint

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ad4789e9c832d8e5b7a91f49b784b