### PR TITLE
chore: add project manifest and pre-commit node builder

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+  - repo: local
+    hooks:
+      - id: node-build
+        name: node-build
+        entry: npm run lint
+        language: node
+        pass_filenames: false

--- a/project.json
+++ b/project.json
@@ -1,0 +1,27 @@
+{
+  "projects": {
+    "api": {
+      "root": "packages/backend",
+      "type": "node",
+      "dependencies": {
+        "compression": "^1.7.4",
+        "cors": "^2.8.5",
+        "dotenv": "^16.3.1",
+        "express": "^4.18.2",
+        "express-rate-limit": "^7.1.5",
+        "helmet": "^7.1.0",
+        "ioredis": "^5.3.2",
+        "joi": "^17.11.0",
+        "socket.io": "^4.6.1",
+        "uuid": "^9.0.1",
+        "winston": "^3.11.0",
+        "xss": "^1.0.15"
+      }
+    },
+    "cli": {
+      "root": "packages/cli",
+      "type": "node",
+      "dependencies": {}
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add root-level project manifest covering API and CLI dependencies
- configure pre-commit with a Node builder running lint checks

## Testing
- `pre-commit run --files project.json .pre-commit-config.yaml`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ada0e4a80832d93720bd5e5af9c79