### PR TITLE
chore: commit changelog directly

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: write
-  pull-requests: write
 
 jobs:
   changelog:
@@ -17,6 +16,9 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
+          fetch-depth: 0
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
@@ -25,13 +27,11 @@ jobs:
         run: npm install
       - name: Generate changelog
         run: npm run changelog
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
-        with:
-          commit-message: "chore: update changelog [skip changelog]"
-          title: "chore: update changelog"
-          body: "Automated update of the changelog."
-          branch: chore/update-changelog
-          base: ${{ github.ref_name }}
-          add-paths: docs/CHANGELOG.md
-          delete-branch: true
+      - name: Commit changelog
+        run: |
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          git add docs/CHANGELOG.md
+          git commit -m "chore: update changelog [skip changelog]" || echo "No changes to commit"
+      - name: Push changes
+        run: git push


### PR DESCRIPTION
## Summary
- commit changelog updates directly to main/master

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ade8783e4832db443adf3229c3c25