### PR TITLE
feat(frontend): add custom 404 page

### DIFF
--- a/packages/frontend/src/pages/404.js
+++ b/packages/frontend/src/pages/404.js
@@ -1,0 +1,19 @@
+import Head from 'next/head';
+import Link from 'next/link';
+
+export default function Custom404() {
+  return (
+    <>
+      <Head>
+        <title>404 - Sayfa Bulunamadı</title>
+      </Head>
+      <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-br from-slate-900 via-blue-900 to-slate-900 text-white">
+        <h1 className="text-6xl font-bold mb-4">404</h1>
+        <p className="text-xl mb-8">Aradığınız sayfa bulunamadı.</p>
+        <Link href="/" className="text-blue-400 hover:underline">
+          Ana sayfaya dön
+        </Link>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add custom 404 page with link back to homepage

## Testing
- `npm test`
- `npm run lint`
- `curl -s http://localhost:3000/nonexistent | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689b4f79d968832d8708f4c61ee937c0