### PR TITLE
fix(frontend): suppress env logs in production

### DIFF
--- a/packages/frontend/src/hooks/useSocket.js
+++ b/packages/frontend/src/hooks/useSocket.js
@@ -12,12 +12,14 @@ export default function useSocket() {
                       process.env.NEXT_PUBLIC_WS_URL || 
                       'http://localhost:3001';
     
-    console.log('🔌 Backend URL:', backendUrl);
-    console.log('🌍 Environment:', process.env.NODE_ENV);
-    console.log('🔧 All env vars:', {
-      API_URL: process.env.NEXT_PUBLIC_API_URL,
-      WS_URL: process.env.NEXT_PUBLIC_WS_URL
-    });
+    if (process.env.NODE_ENV !== 'production') {
+      console.log('🔌 Backend URL:', backendUrl);
+      console.log('🌍 Environment:', process.env.NODE_ENV);
+      console.log('🔧 All env vars:', {
+        API_URL: process.env.NEXT_PUBLIC_API_URL,
+        WS_URL: process.env.NEXT_PUBLIC_WS_URL
+      });
+    }
     
     const newSocket = io(backendUrl, {
       transports: ['polling', 'websocket'], // Polling'i önce dene


### PR DESCRIPTION
## Summary
- wrap environment variable debug logs in `useSocket` so they only run outside production

## Testing
- `npm test`
- `npm run lint`
- `cd packages/frontend && npm run build`
- `NODE_ENV=production npm start` (no env debug logs)

------
https://chatgpt.com/codex/tasks/task_e_689b4f7baa14832d9867a92b9e1948b4