### PR TITLE
feat: enable remote control events

### DIFF
--- a/packages/backend/src/services/signaling.js
+++ b/packages/backend/src/services/signaling.js
@@ -17,6 +17,7 @@ class SignalingService {
     socket.on('offer', (data) => this.handleOffer(socket, data));
     socket.on('answer', (data) => this.handleAnswer(socket, data));
     socket.on('ice-candidate', (data) => this.handleIceCandidate(socket, data));
+    socket.on('control-event', (data) => this.handleControlEvent(socket, data));
     socket.on('disconnect', () => this.handleDisconnect(socket));
   }
 
@@ -147,6 +148,20 @@ class SignalingService {
     logger.debug(`Forwarding ICE candidate from ${socket.id} to ${to}`);
     socket.to(to).emit('ice-candidate', {
       candidate,
+      from: socket.id
+    });
+  }
+
+  async handleControlEvent(socket, event) {
+    const connection = this.connections.get(socket.id);
+    if (!connection) return;
+
+    const { roomId } = connection;
+    const room = await roomService.getRoom(roomId);
+    if (!room) return;
+
+    socket.to(room.hostId).emit('control-event', {
+      ...event,
       from: socket.id
     });
   }

--- a/packages/frontend/src/pages/view.js
+++ b/packages/frontend/src/pages/view.js
@@ -199,7 +199,12 @@ export default function ViewScreen() {
             </div>
           ) : (
             <>
-              <RemoteViewer stream={remoteStream} connected={connected} roomId={roomId} />
+              <RemoteViewer
+                stream={remoteStream}
+                connected={connected}
+                roomId={roomId}
+                socket={socket}
+              />
             </>
           )}
         </div>


### PR DESCRIPTION
## Summary
- send mouse and keyboard events from the viewer to host via Socket.IO
- forward control messages on the backend signaling service
- apply received control events on the host to simulate user input

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c28693230832da6ab1824d908fa35