### PR TITLE
feat: add screen recording support

### DIFF
--- a/packages/backend/src/routes/index.js
+++ b/packages/backend/src/routes/index.js
@@ -3,6 +3,7 @@ const health = require('./health');
 const room = require('./room');
 const stats = require('./stats');
 const analytics = require('./analytics');
+const recordings = require('./recordings');
 
 const router = express.Router();
 
@@ -10,5 +11,6 @@ router.use(health);
 router.use(room);
 router.use(stats);
 router.use(analytics);
+router.use(recordings);
 
 module.exports = router;

--- a/packages/backend/src/routes/recordings.js
+++ b/packages/backend/src/routes/recordings.js
@@ -1,0 +1,28 @@
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+const { apiLimiter } = require('../middleware/rateLimit');
+
+const router = express.Router();
+const uploadsDir = path.join(__dirname, '..', '..', 'uploads');
+
+if (!fs.existsSync(uploadsDir)) {
+  fs.mkdirSync(uploadsDir, { recursive: true });
+}
+
+router.post('/recordings', apiLimiter, async (req, res) => {
+  try {
+    const { name, data } = req.body || {};
+    if (!name || !data) {
+      return res.status(400).json({ error: 'Missing recording data' });
+    }
+    const filePath = path.join(uploadsDir, name);
+    const buffer = Buffer.from(data, 'base64');
+    await fs.promises.writeFile(filePath, buffer);
+    res.json({ success: true, file: name });
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to save recording' });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add MediaRecorder based screen recording with download and upload options
- add backend endpoint for saving uploaded recordings

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c2a379e98832d926c0a8162fa79c3