### PR TITLE
Secure recordings upload against path traversal

### DIFF
--- a/packages/backend/src/routes/__tests__/recordings.test.js
+++ b/packages/backend/src/routes/__tests__/recordings.test.js
@@ -1,0 +1,47 @@
+const request = require('supertest');
+const express = require('express');
+const path = require('path');
+const fs = require('fs/promises');
+const recordings = require('../recordings');
+
+const uploadsDir = path.join(__dirname, '../../../uploads');
+
+describe('POST /recordings', () => {
+  let app;
+
+  beforeEach(async () => {
+    app = express();
+    app.use(express.json());
+    app.use(recordings);
+    await fs.rm(uploadsDir, { recursive: true, force: true });
+    await fs.mkdir(uploadsDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(uploadsDir, { recursive: true, force: true });
+  });
+
+  test('valid filenames are saved successfully', async () => {
+    const res = await request(app)
+      .post('/recordings')
+      .send({ name: 'test.txt', data: 'hello' });
+
+    expect(res.status).toBe(200);
+    const content = await fs.readFile(path.join(uploadsDir, 'test.txt'), 'utf8');
+    expect(content).toBe('hello');
+  });
+
+  test('filenames with path traversal are rejected', async () => {
+    const res = await request(app)
+      .post('/recordings')
+      .send({ name: '../evil.txt', data: 'nope' });
+
+    expect(res.status).toBe(400);
+    const exists = await fs
+      .access(path.join(uploadsDir, 'evil.txt'))
+      .then(() => true)
+      .catch(() => false);
+    expect(exists).toBe(false);
+  });
+});
+

--- a/packages/backend/src/routes/index.js
+++ b/packages/backend/src/routes/index.js
@@ -3,6 +3,7 @@ const health = require('./health');
 const room = require('./room');
 const stats = require('./stats');
 const analytics = require('./analytics');
+const recordings = require('./recordings');
 
 const router = express.Router();
 
@@ -10,5 +11,6 @@ router.use(health);
 router.use(room);
 router.use(stats);
 router.use(analytics);
+router.use(recordings);
 
 module.exports = router;

--- a/packages/backend/src/routes/recordings.js
+++ b/packages/backend/src/routes/recordings.js
@@ -1,0 +1,44 @@
+const express = require('express');
+const path = require('path');
+const { writeFile, mkdir } = require('fs/promises');
+
+const router = express.Router();
+
+const uploadsDir = path.join(__dirname, '../../uploads');
+// Ensure uploads directory exists
+mkdir(uploadsDir, { recursive: true }).catch(() => {});
+
+function sanitizeName(name) {
+  return name.replace(/[^a-zA-Z0-9_.-]/g, '');
+}
+
+router.post('/recordings', async (req, res) => {
+  const { name, data } = req.body || {};
+
+  if (typeof name !== 'string' || typeof data !== 'string') {
+    return res.status(400).json({ error: 'Invalid file data' });
+  }
+
+  const safeName = sanitizeName(name);
+  if (!safeName || safeName !== name) {
+    return res.status(400).json({ error: 'Invalid file name' });
+  }
+
+  const filePath = path.join(uploadsDir, safeName);
+  const resolvedUploads = path.resolve(uploadsDir) + path.sep;
+  const resolvedPath = path.resolve(filePath);
+
+  if (!resolvedPath.startsWith(resolvedUploads)) {
+    return res.status(400).json({ error: 'Invalid file name' });
+  }
+
+  try {
+    await writeFile(resolvedPath, data);
+    res.json({ success: true });
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to save recording' });
+  }
+});
+
+module.exports = router;
+


### PR DESCRIPTION
## Summary
- add recordings route that sanitizes names and ensures paths stay inside uploads directory
- test that valid filenames save and path traversal attempts are rejected

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c2da113a4832d81f2ea9efd1bb5fa