### PR TITLE
feat: display chat beside remote stream

### DIFF
--- a/packages/frontend/src/components/ViewScreenComponent.js
+++ b/packages/frontend/src/components/ViewScreenComponent.js
@@ -148,16 +148,18 @@ export default function ViewScreenComponent() {
               </div>
             </div>
           ) : (
-            <>
-              <RemoteViewer
-                stream={remoteStream}
-                connected={connected}
-                roomId={roomId}
-              />
-              <div className="mt-4">
+            <div className="flex gap-4 h-[calc(100vh-200px)]">
+              <div className="flex-1">
+                <RemoteViewer
+                  stream={remoteStream}
+                  connected={connected}
+                  roomId={roomId}
+                />
+              </div>
+              <div className="w-72">
                 <ChatPanel socket={socket} />
               </div>
-            </>
+            </div>
           )}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- show chat panel next to remote viewer using flex layout

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c5a72cc58832d83dbce6b04df1925