### PR TITLE
feat: reposition chat panel below video feed

### DIFF
--- a/packages/frontend/src/components/ChatPanel.js
+++ b/packages/frontend/src/components/ChatPanel.js
@@ -26,7 +26,7 @@ export default function ChatPanel({ socket }) {
   };
 
   return (
-    <div className="bg-gray-800 rounded-lg p-4 flex flex-col h-64">
+    <div className="bg-gray-800 rounded-lg p-4 flex flex-col h-80">
       <div className="flex-1 overflow-y-auto mb-4">
         {messages.map((msg, idx) => (
           <div key={idx} className="mb-2">

--- a/packages/frontend/src/components/ShareScreenComponent.js
+++ b/packages/frontend/src/components/ShareScreenComponent.js
@@ -343,8 +343,11 @@ export default function ShareScreenComponent() {
                   sharingStartTime={sharingStartTime}
                 />
                 <ViewerChart data={viewerStats} />
-                <ChatPanel socket={socket} />
               </div>
+            </div>
+
+            <div className="mt-8">
+              <ChatPanel socket={socket} />
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- move chat panel out of sidebar and render it beneath the screen share area
- enlarge chat panel height for better visibility

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c5c10adf8832dae97f6015de716f7