### PR TITLE
feat: allow ChatPanel sizing override

### DIFF
--- a/packages/frontend/src/components/ChatPanel.js
+++ b/packages/frontend/src/components/ChatPanel.js
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 
-export default function ChatPanel({ socket }) {
+export default function ChatPanel({ socket, className = 'h-80' }) {
   const [messages, setMessages] = useState([]);
   const [input, setInput] = useState('');
 
@@ -26,7 +26,7 @@ export default function ChatPanel({ socket }) {
   };
 
   return (
-    <div className="bg-gray-800 rounded-lg p-4 flex flex-col h-80">
+    <div className={`bg-gray-800 rounded-lg p-4 flex flex-col ${className}`}>
       <div className="flex-1 overflow-y-auto mb-4">
         {messages.map((msg, idx) => (
           <div key={idx} className="mb-2">

--- a/packages/frontend/src/components/ShareScreenComponent.js
+++ b/packages/frontend/src/components/ShareScreenComponent.js
@@ -347,7 +347,7 @@ export default function ShareScreenComponent() {
             </div>
 
             <div className="mt-8">
-              <ChatPanel socket={socket} />
+              <ChatPanel socket={socket} className="h-80" />
             </div>
           </div>
         </div>

--- a/packages/frontend/src/components/ViewScreenComponent.js
+++ b/packages/frontend/src/components/ViewScreenComponent.js
@@ -157,7 +157,7 @@ export default function ViewScreenComponent() {
                 />
               </div>
               <div className="w-72">
-                <ChatPanel socket={socket} />
+                <ChatPanel socket={socket} className="h-full" />
               </div>
             </div>
           )}


### PR DESCRIPTION
## Summary
- allow overriding ChatPanel height via `className`
- update ShareScreen and ViewScreen to apply custom ChatPanel sizes

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c5ec839dc832d8d557bec831a775c