### PR TITLE
Fix chat panel layout and visibility

### DIFF
--- a/packages/backend/src/services/signaling.js
+++ b/packages/backend/src/services/signaling.js
@@ -17,6 +17,7 @@ class SignalingService {
     socket.on('offer', (data) => this.handleOffer(socket, data));
     socket.on('answer', (data) => this.handleAnswer(socket, data));
     socket.on('ice-candidate', (data) => this.handleIceCandidate(socket, data));
+    socket.on('chat-message', (message) => this.handleChatMessage(socket, message));
     socket.on('disconnect', () => this.handleDisconnect(socket));
   }
 
@@ -147,6 +148,18 @@ class SignalingService {
     logger.debug(`Forwarding ICE candidate from ${socket.id} to ${to}`);
     socket.to(to).emit('ice-candidate', {
       candidate,
+      from: socket.id
+    });
+  }
+
+  handleChatMessage(socket, message) {
+    const connection = this.connections.get(socket.id);
+    if (!connection) return;
+
+    const { roomId } = connection;
+    logger.debug(`Broadcasting chat message from ${socket.id} to room ${roomId}`);
+    this.io.to(roomId).emit('chat-message', {
+      message,
       from: socket.id
     });
   }

--- a/packages/frontend/src/components/ChatPanel.js
+++ b/packages/frontend/src/components/ChatPanel.js
@@ -1,0 +1,57 @@
+import { useState, useEffect } from 'react';
+
+export default function ChatPanel({ socket, className }) {
+  const [messages, setMessages] = useState([]);
+  const [input, setInput] = useState('');
+
+  useEffect(() => {
+    if (!socket) return;
+
+    const handleMessage = ({ message, from }) => {
+      setMessages((prev) => [...prev, { message, from }]);
+    };
+
+    socket.on('chat-message', handleMessage);
+    return () => {
+      socket.off('chat-message', handleMessage);
+    };
+  }, [socket]);
+
+  const sendMessage = (e) => {
+    e.preventDefault();
+    if (!input.trim() || !socket) return;
+
+    socket.emit('chat-message', input);
+    setInput('');
+  };
+
+  const containerClasses = `bg-gray-800 rounded-lg p-4 flex flex-col ${
+    className ?? 'h-80'
+  }`;
+
+  return (
+    <div className={containerClasses}>
+      <div className="flex-1 overflow-y-auto mb-4">
+        {messages.map((msg, idx) => (
+          <div key={idx} className="mb-2">
+            <span className="text-xs text-gray-400 mr-2">
+              {msg.from === socket?.id ? 'You' : msg.from}
+            </span>
+            <span className="text-white">{msg.message}</span>
+          </div>
+        ))}
+      </div>
+      <form onSubmit={sendMessage} className="flex">
+        <input
+          className="flex-1 px-2 py-1 rounded-l bg-gray-700 text-white focus:outline-none"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="Type a message..."
+        />
+        <button type="submit" className="px-4 py-1 bg-blue-600 rounded-r text-white">
+          Send
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/packages/frontend/src/components/ShareScreenComponent.js
+++ b/packages/frontend/src/components/ShareScreenComponent.js
@@ -6,6 +6,7 @@ import Layout from './Layout';
 import ScreenShare from './ScreenShare';
 import ConnectionPanel from './ConnectionPanel';
 import ViewerChart from './ViewerChart';
+import ChatPanel from './ChatPanel';
 import useWebRTC from '../hooks/useWebRTC';
 import useSocket from '../hooks/useSocket';
 
@@ -319,7 +320,7 @@ export default function ShareScreenComponent() {
             </div>
 
             <div className="grid lg:grid-cols-3 gap-8">
-              <div className="lg:col-span-2">
+              <div className="lg:col-span-2 space-y-8">
                 <ScreenShare
                   stream={stream}
                   isSharing={isSharing}
@@ -328,9 +329,10 @@ export default function ShareScreenComponent() {
                   error={error}
                   cameraEnabled={cameraEnabled}
                   microphoneEnabled={microphoneEnabled}
-                  onToggleCamera={() => setCameraEnabled(prev => !prev)}
-                  onToggleMicrophone={() => setMicrophoneEnabled(prev => !prev)}
+                  onToggleCamera={() => setCameraEnabled((prev) => !prev)}
+                  onToggleMicrophone={() => setMicrophoneEnabled((prev) => !prev)}
                 />
+                <ChatPanel socket={socket} />
               </div>
 
               <div className="lg:col-span-1 space-y-8">

--- a/packages/frontend/src/components/ViewScreenComponent.js
+++ b/packages/frontend/src/components/ViewScreenComponent.js
@@ -4,6 +4,7 @@ import Head from 'next/head';
 import { Monitor, Loader, XCircle, Maximize, Volume2 } from 'lucide-react';
 import Layout from './Layout';
 import RemoteViewer from './RemoteViewer';
+import ChatPanel from './ChatPanel';
 import useWebRTC from '../hooks/useWebRTC';
 import useSocket from '../hooks/useSocket';
 
@@ -147,11 +148,16 @@ export default function ViewScreenComponent() {
               </div>
             </div>
           ) : (
-            <RemoteViewer
-              stream={remoteStream}
-              connected={connected}
-              roomId={roomId}
-            />
+            <div className="flex gap-4 h-[calc(100vh-200px)]">
+              <div className="flex-1">
+                <RemoteViewer
+                  stream={remoteStream}
+                  connected={connected}
+                  roomId={roomId}
+                />
+              </div>
+              <ChatPanel socket={socket} className="w-72 h-full" />
+            </div>
           )}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- allow ChatPanel to accept custom classes for flexible sizing
- move broadcaster chat below the stream and show viewer chat beside the video
- ensure chat is visible and usable for both hosts and viewers

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c398b8e18832d868a0ab190dc2d3b