### PR TITLE
chore: set default ECR registry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,3 +35,9 @@ SMTP_HOST=
 SMTP_PORT=587
 SMTP_USER=
 SMTP_PASS=
+
+# Docker image configuration
+# Default registry "myapp" keeps tags valid when ECR_REGISTRY is undefined
+ECR_REGISTRY=myapp
+# Default tag for locally built images
+IMAGE_TAG=latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     build:
       context: .                                 # <-- repo kökü
       dockerfile: packages/frontend/Dockerfile   # <-- dosyanın gerçek yolu
-    image: ${ECR_REGISTRY}/myapp-frontend:${IMAGE_TAG}   # ECR'e pushlamak için
+    image: ${ECR_REGISTRY:-myapp}/myapp-frontend:${IMAGE_TAG:-latest}   # ECR'e pushlamak için
     ports:
       - "3003:3000"
     environment:
@@ -18,7 +18,7 @@ services:
     build:
       context: .                                 # <-- repo kökü
       dockerfile: packages/backend/Dockerfile
-    image: ${ECR_REGISTRY}/myapp-backend:${IMAGE_TAG}
+    image: ${ECR_REGISTRY:-myapp}/myapp-backend:${IMAGE_TAG:-latest}
     ports:
       - "3002:3001"
     environment:


### PR DESCRIPTION
## Summary
- default `ECR_REGISTRY` to `myapp` in docker compose
- document the `myapp` default in `.env.example`

## Testing
- `npm test`
- `npm run lint`
- `pre-commit run --files docker-compose.yml .env.example`


------
https://chatgpt.com/codex/tasks/task_e_68a6f71b4e58832d91f067e7eaae1dec