### PR TITLE
Potential fix for code scanning alert no. 5: Incomplete multi-character sanitization

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -22,7 +22,8 @@
     "joi": "^17.11.0",
     "socket.io": "^4.6.1",
     "uuid": "^9.0.1",
-    "winston": "^3.11.0"
+    "winston": "^3.11.0",
+    "sanitize-html": "^2.17.0"
   },
   "devDependencies": {
     "eslint": "^8.54.0",

--- a/packages/backend/src/utils/validators.js
+++ b/packages/backend/src/utils/validators.js
@@ -1,3 +1,4 @@
+const sanitizeHtml = require('sanitize-html');
 const Joi = require('joi');
 
 // Room validation schemas
@@ -92,10 +93,7 @@ module.exports = {
   
   sanitizeInput: (input) => {
     if (typeof input !== 'string') return input;
-    
-    // Remove any HTML tags and trim whitespace
-    return input
-      .replace(/<[^>]*>/g, '')
-      .trim();
+    // Remove all HTML tags and attributes using sanitize-html, then trim whitespace
+    return sanitizeHtml(input, { allowedTags: [], allowedAttributes: {} }).trim();
   }
 };


### PR DESCRIPTION
Potential fix for [https://github.com/JustTechCom/JustDesk/security/code-scanning/5](https://github.com/JustTechCom/JustDesk/security/code-scanning/5)

The best way to fix this problem is to use a well-tested sanitization library, such as `sanitize-html`, which is specifically designed to remove unsafe HTML tags and attributes. This approach is robust and handles edge cases that custom regular expressions cannot. If using a library is not an option, a safer alternative is to repeatedly apply the regular expression replacement until no more matches are found, ensuring that all tags are removed. However, using a library is strongly preferred for security and maintainability.

**Required changes:**  
- Add an import for the `sanitize-html` library at the top of the file.
- Replace the implementation of `sanitizeInput` to use `sanitizeHtml(input, { allowedTags: [], allowedAttributes: {} })`, which strips all HTML tags and attributes.
- If the library cannot be used, as a fallback, apply the regular expression replacement in a loop until the input no longer changes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
